### PR TITLE
Swap order of klass and key arguments to form DSL method

### DIFF
--- a/fern-api.gemspec
+++ b/fern-api.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'fern/api/version'

--- a/lib/fern/api/endpoint.rb
+++ b/lib/fern/api/endpoint.rb
@@ -12,7 +12,7 @@ module Fern
         @controller.send(:define_method, @name, &block)
       end
 
-      def form(key = nil, klass) # rubocop:disable Style/OptionalArguments
+      def form(klass, key = nil)
         @controller.fern[@name][:form] = {
           key: key,
           klass: klass

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
 require 'active_support'
 require 'action_controller'


### PR DESCRIPTION
The `klass` and `key` arguments to the `form` DSL method were backwards, with the optional `key` coming before the required `klass`.

This is a breaking change to the DSL, but a trivial one to fix in client code. I think it's probably best to fix this now, because it's only going to get more painful to fix in the future.

This also makes a couple of changes to keep Rubocop happy.